### PR TITLE
Threaded Decorator Type-Safety

### DIFF
--- a/src/thread/_types.py
+++ b/src/thread/_types.py
@@ -5,6 +5,7 @@ Documentation: https://thread.ngjx.org
 """
 
 from typing import Any, Literal, Callable, Union
+from typing_extensions import ParamSpec, TypeVar
 
 
 # Descriptive Types
@@ -27,5 +28,10 @@ ThreadStatus = Literal[
 
 
 # Function types
-HookFunction = Callable[[Data_Out], Union[Any, None]]
-TargetFunction = Callable[..., Data_Out]
+_Target_P = ParamSpec('_Target_P')
+_Target_T = TypeVar('_Target_T')
+_Dataset_T = TypeVar('_Dataset_T')
+
+TargetFunction = Callable[_Target_P, _Target_T]
+
+HookFunction = Callable[[_Target_T], Union[Any, None]]

--- a/src/thread/_types.py
+++ b/src/thread/_types.py
@@ -30,8 +30,9 @@ ThreadStatus = Literal[
 # Function types
 _Target_P = ParamSpec('_Target_P')
 _Target_T = TypeVar('_Target_T')
-_Dataset_T = TypeVar('_Dataset_T')
-
 TargetFunction = Callable[_Target_P, _Target_T]
 
 HookFunction = Callable[[_Target_T], Union[Any, None]]
+
+_Dataset_T = TypeVar('_Dataset_T')
+DatasetFunction = Callable[[_Dataset_T], _Target_T]

--- a/src/thread/decorators.py
+++ b/src/thread/decorators.py
@@ -14,15 +14,15 @@ from typing_extensions import ParamSpec, TypeVar
 
 T = TypeVar('T')
 P = ParamSpec('P')
-TargetFunction = Callable[P, Data_Out]
+TargetFunction = Callable[P, T]
 NoParamReturn = Callable[P, Thread[P, T]]
-WithParamReturn = Callable[[TargetFunction[P]], NoParamReturn[P, T]]
-FullParamReturn = Callable[P, Thread]
-WrappedWithParamReturn = Callable[[TargetFunction[P]], WithParamReturn[P, T]]
+WithParamReturn = Callable[[TargetFunction[P, T]], NoParamReturn[P, T]]
+FullParamReturn = Callable[P, Thread[P, T]]
+WrappedWithParamReturn = Callable[[TargetFunction[P, T]], WithParamReturn[P, T]]
 
 
 @overload
-def threaded(__function: TargetFunction[P]) -> NoParamReturn[P, T]: ...
+def threaded(__function: TargetFunction[P, T]) -> NoParamReturn[P, T]: ...
 
 @overload
 def threaded(
@@ -36,25 +36,25 @@ def threaded(
 
 @overload
 def threaded(
-  __function: Callable[P, Data_Out],
+  __function: TargetFunction[P, T],
   *,
   args: Sequence[Data_In] = (),
   kwargs: Mapping[str, Data_In] = {},
   ignore_errors: Sequence[type[Exception]] = (),
   suppress_errors: bool = False,
   **overflow_kwargs: Overflow_In
-) -> FullParamReturn[P]: ...
+) -> FullParamReturn[P, T]: ...
 
 
 def threaded(
-  __function: Optional[TargetFunction[P]] = None,
+  __function: Optional[TargetFunction[P, T]] = None,
   *,
   args: Sequence[Data_In] = (),
   kwargs: Mapping[str, Data_In] = {},
   ignore_errors: Sequence[type[Exception]] = (),
   suppress_errors: bool = False,
   **overflow_kwargs: Overflow_In
-) -> Union[NoParamReturn[P, T], WithParamReturn[P, T], FullParamReturn[P]]:
+) -> Union[NoParamReturn[P, T], WithParamReturn[P, T], FullParamReturn[P, T]]:
   """
   Decorate a function to run it in a thread
 
@@ -96,7 +96,7 @@ def threaded(
   """
 
   if not callable(__function):
-    def wrapper(func: TargetFunction[P]) -> FullParamReturn[P]:
+    def wrapper(func: TargetFunction[P, T]) -> FullParamReturn[P, T]:
       return threaded(
         func,
         args = args,
@@ -115,7 +115,7 @@ def threaded(
   kwargs = dict(kwargs)
   
   @wraps(__function)
-  def wrapped(*parsed_args: P.args, **parsed_kwargs: P.kwargs) -> Thread:
+  def wrapped(*parsed_args: P.args, **parsed_kwargs: P.kwargs) -> Thread[P, T]:
     kwargs.update(parsed_kwargs)
 
     processed_args = ( *args, *parsed_args )

--- a/src/thread/decorators.py
+++ b/src/thread/decorators.py
@@ -15,14 +15,14 @@ from typing_extensions import ParamSpec, TypeVar
 T = TypeVar('T')
 P = ParamSpec('P')
 TargetFunction = Callable[P, Data_Out]
-NoParamReturn = Callable[P, Thread]
-WithParamReturn = Callable[[TargetFunction], NoParamReturn]
+NoParamReturn = Callable[P, Thread[P, T]]
+WithParamReturn = Callable[[TargetFunction[P]], NoParamReturn[P, T]]
 FullParamReturn = Callable[P, Thread]
-WrappedWithParamReturn = Callable[[TargetFunction], WithParamReturn]
+WrappedWithParamReturn = Callable[[TargetFunction[P]], WithParamReturn[P, T]]
 
 
 @overload
-def threaded(__function: TargetFunction) -> NoParamReturn: ...
+def threaded(__function: TargetFunction[P]) -> NoParamReturn[P, T]: ...
 
 @overload
 def threaded(
@@ -32,7 +32,7 @@ def threaded(
   ignore_errors: Sequence[type[Exception]] = (),
   suppress_errors: bool = False,
   **overflow_kwargs: Overflow_In
-) -> WithParamReturn: ...
+) -> WithParamReturn[P, T]: ...
 
 @overload
 def threaded(
@@ -43,18 +43,18 @@ def threaded(
   ignore_errors: Sequence[type[Exception]] = (),
   suppress_errors: bool = False,
   **overflow_kwargs: Overflow_In
-) -> FullParamReturn: ...
+) -> FullParamReturn[P]: ...
 
 
 def threaded(
-  __function: Optional[TargetFunction] = None,
+  __function: Optional[TargetFunction[P]] = None,
   *,
   args: Sequence[Data_In] = (),
   kwargs: Mapping[str, Data_In] = {},
   ignore_errors: Sequence[type[Exception]] = (),
   suppress_errors: bool = False,
   **overflow_kwargs: Overflow_In
-) -> Union[NoParamReturn, WithParamReturn, FullParamReturn]:
+) -> Union[NoParamReturn[P, T], WithParamReturn[P, T], FullParamReturn[P]]:
   """
   Decorate a function to run it in a thread
 
@@ -96,7 +96,7 @@ def threaded(
   """
 
   if not callable(__function):
-    def wrapper(func: TargetFunction) -> FullParamReturn:
+    def wrapper(func: TargetFunction[P]) -> FullParamReturn[P]:
       return threaded(
         func,
         args = args,

--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -25,7 +25,7 @@ from ._types import (
   DatasetFunction, _Dataset_T,
   HookFunction
 )
-from typing_extensions import Generic, Concatenate, ParamSpec
+from typing_extensions import Generic, ParamSpec
 from typing import (
   List,
   Callable, Optional, Union,

--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -19,16 +19,22 @@ from . import exceptions
 from .utils.config import Settings
 from .utils.algorithm import chunk_split
 
-from ._types import ThreadStatus, Data_In, Data_Out, Overflow_In, TargetFunction, HookFunction
+from ._types import (
+  ThreadStatus, Data_In, Data_Out, Overflow_In,
+  TargetFunction, _Target_P, _Target_T,
+  DatasetFunction, _Dataset_T,
+  HookFunction
+)
+from typing_extensions import Generic
 from typing import (
-  Any, List,
-  Callable, Optional,
+  Any, List, Unpack,
+  Callable, Optional, Union,
   Mapping, Sequence, Tuple
 )
 
 
 Threads: set['Thread'] = set()
-class Thread(threading.Thread):
+class Thread(threading.Thread, Generic[_Target_P, _Target_T]):
   """
   Wraps python's `threading.Thread` class
   ---------------------------------------
@@ -51,7 +57,7 @@ class Thread(threading.Thread):
 
   def __init__(
     self,
-    target: TargetFunction,
+    target: TargetFunction[_Target_P, _Target_T],
     args: Sequence[Data_In] = (),
     kwargs: Mapping[str, Data_In] = {},
     ignore_errors: Sequence[type[Exception]] = (),
@@ -100,10 +106,10 @@ class Thread(threading.Thread):
     )
 
 
-  def _wrap_target(self, target: TargetFunction) -> TargetFunction:
+  def _wrap_target(self, target: TargetFunction[_Target_P, _Target_T]) -> TargetFunction[_Target_P, Union[_Target_T, None]]:
     """Wraps the target function"""
     @wraps(target)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args: _Target_P.args, **kwargs: _Target_P.kwargs) -> Union[_Target_T, None]:
       self.status = 'Running'
 
       global Threads
@@ -173,7 +179,7 @@ class Thread(threading.Thread):
     
 
   @property
-  def result(self) -> Data_Out:
+  def result(self) -> _Target_T:
     """
     The return value of the thread
     
@@ -208,7 +214,7 @@ class Thread(threading.Thread):
     return super().is_alive()
     
 
-  def add_hook(self, hook: HookFunction) -> None:
+  def add_hook(self, hook: HookFunction[_Target_T]) -> None:
     """
     Adds a hook to the thread
     -------------------------
@@ -250,7 +256,7 @@ class Thread(threading.Thread):
     return not self.is_alive()
   
 
-  def get_return_value(self) -> Data_Out:
+  def get_return_value(self) -> _Target_T:
     """
     Halts the current thread execution until the thread completes
 
@@ -323,7 +329,7 @@ class _ThreadWorker:
     self.thread = thread
     self.progress = progress
 
-class ParallelProcessing:
+class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
   """
   Multi-Threaded Parallel Processing
   ---------------------------------------
@@ -335,7 +341,7 @@ class ParallelProcessing:
   _completed     : int
 
   status         : ThreadStatus
-  function       : Callable[..., List[Data_Out]]
+  function       : TargetFunction[..., List[_Target_T]]
   dataset        : Sequence[Data_In]
   max_threads    : int
   
@@ -344,8 +350,8 @@ class ParallelProcessing:
   
   def __init__(
     self,
-    function: TargetFunction,
-    dataset: Sequence[Data_In],
+    function: DatasetFunction[_Dataset_T, _Target_T],
+    dataset: Sequence[_Dataset_T],
     max_threads: int = 8,
 
     *overflow_args: Overflow_In,
@@ -385,10 +391,10 @@ class ParallelProcessing:
 
   def _wrap_function(
     self,
-    function: TargetFunction
-  ) -> Callable[..., List[Data_Out]]:
+    function: TargetFunction[[_Dataset_T], _Target_T]
+  ) -> TargetFunction[..., List[_Target_T]]:
     @wraps(function)
-    def wrapper(index: int, data_chunk: Sequence[Data_In], *args: Any, **kwargs: Any) -> List[Data_Out]:
+    def wrapper(index: int, data_chunk: Sequence[_Dataset_T], *args: _Target_P.args, **kwargs: _Target_P.kwargs) -> List[_Target_T]:
       computed: List[Data_Out] = []
       for i, data_entry in enumerate(data_chunk):
         v = function(data_entry, *args, **kwargs)
@@ -404,7 +410,7 @@ class ParallelProcessing:
 
 
   @property
-  def results(self) -> Data_Out:
+  def results(self) -> List[_Dataset_T]:
     """
     The return value of the threads if completed
     
@@ -436,7 +442,7 @@ class ParallelProcessing:
     return any(entry.thread.is_alive() for entry in self._threads)
   
 
-  def get_return_values(self) -> List[Data_Out]:
+  def get_return_values(self) -> List[_Dataset_T]:
     """
     Halts the current thread execution until the thread completes
 

--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -27,7 +27,7 @@ from ._types import (
 )
 from typing_extensions import Generic
 from typing import (
-  Any, List, Unpack,
+  List,
   Callable, Optional, Union,
   Mapping, Sequence, Tuple
 )

--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -44,7 +44,7 @@ class Thread(threading.Thread, Generic[_Target_P, _Target_T]):
 
   status         : ThreadStatus
   hooks          : List[HookFunction]
-  returned_value: Data_Out
+  _returned_value: Data_Out
 
   errors         : List[Exception]
   ignore_errors  : Sequence[type[Exception]]
@@ -86,7 +86,7 @@ class Thread(threading.Thread, Generic[_Target_P, _Target_T]):
     :param **: These are arguments parsed to `thread.Thread`
     """
     _target = self._wrap_target(target)
-    self.returned_value = None
+    self._returned_value = None
     self.status = 'Idle'
     self.hooks = []
 
@@ -116,7 +116,7 @@ class Thread(threading.Thread, Generic[_Target_P, _Target_T]):
       Threads.add(self)
 
       try:
-        self.returned_value = target(*args, **kwargs)
+        self._returned_value = target(*args, **kwargs)
       except Exception as e:
         if not any(isinstance(e, ignore) for ignore in self.ignore_errors):
           self.status = 'Errored'
@@ -135,7 +135,7 @@ class Thread(threading.Thread, Generic[_Target_P, _Target_T]):
     errors: List[Tuple[Exception, str]] = []
     for hook in self.hooks:
       try:
-        hook(self.returned_value)
+        hook(self._returned_value)
       except Exception as e:
         if not any(isinstance(e, ignore) for ignore in self.ignore_errors):
           errors.append((
@@ -196,7 +196,7 @@ class Thread(threading.Thread, Generic[_Target_P, _Target_T]):
     
     self._handle_exceptions()
     if self.status in ['Invoking hooks', 'Completed']:
-      return self.returned_value
+      return self._returned_value
     else:
       raise exceptions.ThreadStillRunningError()
     

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,6 +1,5 @@
 import time
-import pytest
-from src.thread import threaded, exceptions
+from src.thread import threaded
 
 
 # >>>>>>>>>> Dummy Functions <<<<<<<<<< #

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -8,15 +8,6 @@ def _dummy_target_raiseToPower(x: float, power: float, delay: float = 0):
   time.sleep(delay)
   return x**power
 
-def _dummy_raiseException(x: Exception, delay: float = 0):
-  time.sleep(delay)
-  raise x
-
-def _dummy_iterative(itemCount: int, pTime: float = 0.1, delay: float = 0):
-  time.sleep(delay)
-  for i in range(itemCount):
-    time.sleep(pTime)
-
 
 
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the our Code of Conduct: https://github.com/python-thread/thread/blob/main/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Breaking Change
- [ ] Documentation Update



## Description
Made the use of threaded decorators type-safe by overriding the original function's signature with ParamSpec and TypeVar.



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #32 



## QA Instructions, Screenshots, Recordings

### Boilerplate code
```py
import thread

@thread.threaded
def a(x: int):
  return 2 + x

a1 = a(3)
a2 = a1.result
a3 = a1.get_return_value()


@thread.threaded()
def b(x: int):
  return 2 + x

b1 = b(3)
b2 = b1.result
b3 = b1.get_return_value()


@thread.threaded()
def c(x: int):
  return 2 + x

c1 = c(3)
c2 = c1.result
c3 = c1.get_return_value()

```

#

### Intellisense should type hint correctly

![image](https://github.com/python-thread/thread/assets/104479537/ec68b4e6-79fe-42f5-a87c-cd235f7f89b0)
![image](https://github.com/python-thread/thread/assets/104479537/c7320350-8c10-4f8f-9f1e-9aab55e64bd1)
![image](https://github.com/python-thread/thread/assets/104479537/4969ae9c-eccf-4542-b2b2-92fc5b4e74df)
![image](https://github.com/python-thread/thread/assets/104479537/0b840485-9674-41f4-b949-b7858fa363b7)





## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: Untestable change
- [ ] I need help with writing tests



## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.