### PR TITLE
Perf: memory optimisation for ParallelProcessing

### DIFF
--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -512,9 +512,16 @@ class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
     }
 
     i = 0
+    for chunkStart, chunkEnd in chunk_split(len(self.dataset), max_threads):
       chunk_thread = Thread(
         target=self.function,
-        args=[i, data_chunk, *parsed_args, *self.overflow_args],
+        args=[
+          i,
+          chunkEnd - chunkStart,
+          (self.dataset[x] for x in range(chunkStart, chunkEnd)),
+          *parsed_args,
+          *self.overflow_args,
+        ],
         name=name_format and name_format % i or None,
         **self.overflow_kwargs,
       )

--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -392,10 +392,13 @@ class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
       **kwargs: _Target_P.kwargs,
       ) -> List[_Target_T]:
       computed: List[Data_Out] = []
-      for i, data_entry in enumerate(data_chunk):
+
+      i = 0
+      for data_entry in data_chunk:
         v = function(data_entry, *args, **kwargs)
         computed.append(v)
         self._threads[index].progress = round((i + 1) / len(data_chunk), 5)
+        i += 1
 
       self._completed += 1
       if self._completed == len(self._threads):
@@ -507,7 +510,7 @@ class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
       i: v for i, v in self.overflow_kwargs.items() if i != 'name' and i != 'args'
     }
 
-    for i, data_chunk in enumerate(chunk_split(self.dataset, max_threads)):
+    i = 0
       chunk_thread = Thread(
         target=self.function,
         args=[i, data_chunk, *parsed_args, *self.overflow_args],
@@ -516,6 +519,7 @@ class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
       )
       self._threads.append(_ThreadWorker(chunk_thread, 0))
       chunk_thread.start()
+      i += 1
 
 
 # Handle abrupt exit

--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -387,6 +387,7 @@ class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
     @wraps(function)
     def wrapper(
       index: int,
+      length: int,
       data_chunk: Generator[_Dataset_T, None, None],
       *args: _Target_P.args,
       **kwargs: _Target_P.kwargs,
@@ -397,7 +398,7 @@ class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
       for data_entry in data_chunk:
         v = function(data_entry, *args, **kwargs)
         computed.append(v)
-        self._threads[index].progress = round((i + 1) / len(data_chunk), 5)
+        self._threads[index].progress = round((i + 1) / length, 5)
         i += 1
 
       self._completed += 1

--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -32,7 +32,7 @@ from ._types import (
   HookFunction,
 )
 from typing_extensions import Generic, ParamSpec
-from typing import List, Callable, Optional, Union, Mapping, Sequence, Tuple
+from typing import List, Callable, Optional, Union, Mapping, Sequence, Tuple, Generator
 
 
 Threads: set['Thread'] = set()
@@ -387,7 +387,7 @@ class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
     @wraps(function)
     def wrapper(
       index: int,
-      data_chunk: Sequence[_Dataset_T],
+      data_chunk: Generator[_Dataset_T, None, None],
       *args: _Target_P.args,
       **kwargs: _Target_P.kwargs,
       ) -> List[_Target_T]:

--- a/src/thread/utils/algorithm.py
+++ b/src/thread/utils/algorithm.py
@@ -21,13 +21,13 @@ def chunk_split(dataset_length: int, number_of_chunks: int) -> List[Tuple[int, i
 
   Parameters
   ----------
-  :param dataset: This should be the dataset you want to split into chunks
+  :param dataset_length: This should be the length of the dataset you want to split into chunks
   :param number_of_chunks: The should be the number of chunks it will attempt to split into
 
 
   Returns
   -------
-  :returns list[list[Any]]: The split dataset
+  :returns list[tuple[int, int]]: The chunked dataset slices
 
   Raises
   ------

--- a/src/thread/utils/algorithm.py
+++ b/src/thread/utils/algorithm.py
@@ -46,7 +46,7 @@ def chunk_split(dataset_length: int, number_of_chunks: int) -> List[Tuple[int, i
     chunk_length = chunk_count + int(overflow > 0)
     b = i + chunk_length
 
-    split.append(dataset[i:b])
+    split.append((i, b))
     overflow -= 1
     i = b
 

--- a/src/thread/utils/algorithm.py
+++ b/src/thread/utils/algorithm.py
@@ -8,10 +8,10 @@ If it gets too dense, we could consider splitting it into a library import
   |_ b.py
 """
 
-from typing import List, Sequence, Any
+from typing import List, Tuple
 
 
-def chunk_split(dataset: Sequence[Any], number_of_chunks: int) -> List[List[Any]]:
+def chunk_split(dataset_length: int, number_of_chunks: int) -> List[Tuple[int, int]]:
   """
   Splits a dataset into balanced chunks
 

--- a/src/thread/utils/algorithm.py
+++ b/src/thread/utils/algorithm.py
@@ -33,17 +33,16 @@ def chunk_split(dataset_length: int, number_of_chunks: int) -> List[Tuple[int, i
   ------
   AssertionError: The number of chunks specified is larger than the dataset size
   """
-  length = len(dataset)
   assert (
-    length >= number_of_chunks
+    dataset_length >= number_of_chunks
   ), 'The number of chunks specified is larger than the dataset size'
 
-  chunk_count = length // number_of_chunks
-  overflow = length % number_of_chunks
+  chunk_count = dataset_length // number_of_chunks
+  overflow = dataset_length % number_of_chunks
 
   i = 0
   split = []
-  while i < length:
+  while i < dataset_length:
     chunk_length = chunk_count + int(overflow > 0)
     b = i + chunk_length
 

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1,0 +1,22 @@
+from src.thread.utils import algorithm
+
+
+def test_chunking_1():
+  assert algorithm.chunk_split(5, 1) == [(0, 5)]
+
+
+def test_chunking_2():
+  assert algorithm.chunk_split(5, 2) == [(0, 3), (3, 5)]
+
+
+def test_chunking_3():
+  assert algorithm.chunk_split(100, 8) == [
+    (0, 13),
+    (13, 26),
+    (26, 39),
+    (39, 52),
+    (52, 64),
+    (64, 76),
+    (76, 88),
+    (88, 100),
+  ]

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1,3 +1,4 @@
+import random
 from src.thread.utils import algorithm
 
 
@@ -20,3 +21,25 @@ def test_chunking_3():
     (76, 88),
     (88, 100),
   ]
+
+
+def test_chunking_dynamic():
+  dataset_length = random.randint(400, int(10e6))
+  thread_count = random.randint(2, 100)
+
+  expected_chunk_length_low = dataset_length // thread_count
+  expected_chunk_high = dataset_length % thread_count
+
+  i = 0
+  heap = []
+  while i < dataset_length:
+    chunk_length = expected_chunk_length_low + int(expected_chunk_high > 0)
+    b = i + chunk_length
+
+    heap.append((i, b))
+    expected_chunk_high -= 1
+    i = b
+
+  assert (
+    algorithm.chunk_split(dataset_length, thread_count) == heap
+  ), f'\nLength: {dataset_length}\nThreads: {thread_count}\nExpected: {heap}\nActual: {algorithm.chunk_split(dataset_length, thread_count)}'


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the our Code of Conduct: https://github.com/python-thread/thread/blob/main/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization



## Description

- Improves memory efficiency
- Improves runtime



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #45 



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests




## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.