### PR TITLE
fix tests directory shouldn't have init.py

### DIFF
--- a/.github/workflows/test-worker.yml
+++ b/.github/workflows/test-worker.yml
@@ -54,6 +54,7 @@ jobs:
           python -m poetry self add poetry-plugin-export
           python -m poetry export -f requirements.txt --output requirements.txt
           python -m pip install -r requirements.txt
+          python -m pip install .
 
       - name: Test with pytest
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,7 +32,7 @@ keywords:
 license: BSD-3-Clause
 message: If you use this software, please cite it using these metadata.
 repository-code: https://github.com/python-thread/thread
-reposistory-artifact: https://pypi.org/project/thread
+repository-artifact: https://pypi.org/project/thread
 title: thread
 type: software
 version: 1.0.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-# Need this file, else it can't import src.thread

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1,5 +1,6 @@
 import random
-from src.thread.utils import algorithm
+
+from thread.utils import algorithm
 
 
 def test_chunking_1():

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,5 +1,6 @@
 import time
-from src.thread import threaded, processor
+
+from thread import threaded, processor
 
 
 # >>>>>>>>>> Dummy Functions <<<<<<<<<< #

--- a/tests/test_parallelprocessing.py
+++ b/tests/test_parallelprocessing.py
@@ -1,6 +1,8 @@
 import time
+
 import pytest
-from src.thread import ParallelProcessing, exceptions
+
+from thread import ParallelProcessing, exceptions
 
 
 # >>>>>>>>>> Dummy Functions <<<<<<<<<< #

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -1,6 +1,8 @@
 import time
+
 import pytest
-from src.thread import Thread, exceptions
+
+from thread import Thread, exceptions
 
 
 # >>>>>>>>>> Dummy Functions <<<<<<<<<< #


### PR DESCRIPTION
The tests directory shouldn't have an `__init.py__` and the imports into your package should just use the package name not `src.packagename`.

See: https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#tests-outside-application-code

I've ran the tests locally in a virtualenv to verify it works, and the tests passed locally.