### PR TITLE
Fix: enforce nonempty dataset

### DIFF
--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -368,8 +368,10 @@ class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
 
         Raises
         ------
+        AssertionError: invalid `dataset`
         AssertionError: invalid `max_threads`
         """
+        assert len(dataset) > 0, 'dataset cannot be empty'
         assert 0 <= max_threads, 'max_threads cannot be set to 0'
 
         self._threads = []

--- a/src/thread/thread.py
+++ b/src/thread/thread.py
@@ -370,7 +370,7 @@ class ParallelProcessing(Generic[_Target_P, _Target_T, _Dataset_T]):
         ------
         AssertionError: invalid `max_threads`
         """
-        assert 0 <= max_threads, 'Cannot run a thread pool with max threads set to 0'
+        assert 0 <= max_threads, 'max_threads cannot be set to 0'
 
         self._threads = []
         self._completed = 0


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the our Code of Conduct: https://github.com/python-thread/thread/blob/main/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Breaking Change
- [ ] Documentation Update



## Description

- Enforce non-empty dataset



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #68 



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests




## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.