### PR TITLE
fix: Cast verbosity comparison to Literal type

### DIFF
--- a/src/thread/utils/config.py
+++ b/src/thread/utils/config.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Literal, Union
+from typing import Any, Callable, Literal, Union, cast
 
 _Verbosity_Num = Literal[0, 1, 2]
 _Verbosity_Enum = Literal['quiet', 'normal', 'verbose']
@@ -79,6 +79,7 @@ class Verbosity:
             return operator(self.level_number, other)
         if isinstance(other, str):
             if Verbosity.is_valid_level(other):
+                other = cast(_Verbosity_Enum, other)
                 return operator(self.level_number, VerbosityMapping[other])
             return operator(self.level_string, other)
         raise ValueError('Cannot compare Verbosity with other types')


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the our Code of Conduct: https://github.com/python-thread/thread/blob/main/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Breaking Change
- [ ] Documentation Update



## Description

- Cast string type to string literal type



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #



## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: No need
- [ ] I need help with writing tests



## [optional] Are there any post deployment tasks we need to perform?




## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have incremented the version according to [semantic versioning](https://semver.org/).
- [ ] I have updated the changelog accordingly.
